### PR TITLE
Feat/verify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3513,9 +3513,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
+    "elliptic": "^6.4.1",
     "jest": "^23.6.0"
   },
   "dependencies": {
@@ -39,6 +40,12 @@
   },
   "jest": {
     "coverageDirectory": ".coverage",
-    "testPathIgnorePatterns": ["/node_modules/", "/lib/", "/dist/", "/demo/"]
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/lib/",
+      "/dist/",
+      "/demo/"
+    ]
   }
 }

--- a/src/Domain.js
+++ b/src/Domain.js
@@ -3,7 +3,7 @@ import { keccak256 } from 'js-sha3'
 
 import AbstractType from './AbstractType'
 import Type from './Type'
-import { validate as validatePrimitive, isArrayType, isPrimitiveType, getBaseType } from './primitives'
+import { validate as validatePrimitive, isArrayType, isPrimitiveType, getElementaryType } from './primitives'
 
 // The set of properties that a EIP712Domain MAY implement
 export const EIP712DomainProperties = [
@@ -93,7 +93,7 @@ export default function EIP712Domain(def) {
     validate(type, val) {
       if (isArrayType(type)) {
         // Apply the validator to each item in an array, using the base type
-        return val.map(item => this.validate(getBaseType(type), item))
+        return val.map(item => this.validate(getElementaryType(type), item))
       } else if (isPrimitiveType(type)) {
         return validatePrimitive[type](val)
       } else if (type in this.types) {
@@ -119,7 +119,7 @@ export default function EIP712Domain(def) {
         return val.toObject()
       } else if (isArrayType(type)) {
         // Map serializer to array types
-        return val.map(item => this.serialize(getBaseType(type), item))
+        return val.map(item => this.serialize(getElementaryType(type), item))
       } else if (isPrimitiveType(type)) {
         return val
       } else {

--- a/src/__tests__/AbstractType.test.js
+++ b/src/__tests__/AbstractType.test.js
@@ -4,6 +4,11 @@ describe('AbstractType', () => {
   it('constructs', () => {
     expect(() => new AbstractType()).not.toThrow()
   })
+
+  it('throws errors on abstract methods', () => {
+    expect(() => (new AbstractType()).encodeData()).toThrow()
+    expect(() => (new AbstractType()).toObject()).toThrow()
+  })
 })
 
 describe('Concrete subtypes of abstract type', () => {

--- a/src/__tests__/Domain.test.js
+++ b/src/__tests__/Domain.test.js
@@ -13,6 +13,7 @@ const miniDomain = {
   version: '1.0'
 }
 
+
 describe('EIP712Domain', () => {
   it('creates a domain with all domain properties', () => {
     expect(() => new EIP712Domain(domainDef)).not.toThrow()
@@ -119,8 +120,60 @@ describe('toObject', () => {
   })
 })
 
-describe('Types in the Domain', () => {
-  it('Creates a valid signature request', () => {
+describe('fromSignatureRequest', () => {
+  it('creates a simple domain/message', () => {
+    const request = {
+      types: {
+        EIP712Domain: EIP712DomainProperties,
+        LilType: [
+          {name: 'data', type: 'string'}
+        ]
+      },
+      domain: domainDef,
+      primaryType: 'LilType',
+      message: {
+        data: 'Hello World!'
+      }
+    }
+    const { domain, message } = EIP712Domain.fromSignatureRequest(request)
 
+    expect(domain.toObject()).toEqual(domainDef)
+    expect(message.toObject()).toEqual(request.message)
+  })
+
+  it('creates a domain with nested types', () => {
+    const request = {
+      types: {
+        EIP712Domain: EIP712DomainProperties,
+        MiddleType: [
+          {name: 'woop', type: 'string'},
+          {name: 'lil', type: 'LilType'}
+        ],
+        SuperType: [
+          {name: 'woop', type: 'string'},
+          {name: 'lil', type: 'LilType'},
+          {name: 'middle', type: 'MiddleType'}
+        ],
+        LilType: [
+          {name: 'data', type: 'string'}
+        ]
+      },
+      domain: domainDef,
+      primaryType: 'SuperType',
+      message: {
+        woop: 'woop',
+        lil: { data: 'lil type' },
+        middle: {
+          woop: 'woop in the middle',
+          lil: { data: 'lil type in the middle' }
+        }
+      }
+    }
+
+    const { domain, message } = EIP712Domain.fromSignatureRequest(request)
+
+    expect(domain.toObject()).toEqual(domainDef)
+    expect(message.toObject()).toEqual(request.message)
+    expect(message.toSignatureRequest()).toEqual(request)
   })
 })

--- a/src/__tests__/primitives.test.js
+++ b/src/__tests__/primitives.test.js
@@ -1,4 +1,4 @@
-import { isPrimitiveType, isAtomicType, isDynamicType, isArrayType } from '../primitives'
+import { validate, isPrimitiveType, isAtomicType, isDynamicType, isArrayType, getElementaryType } from '../primitives'
 
 const POWERS = [1, 2, 4, 8, 16, 32]
 
@@ -56,10 +56,24 @@ describe('type indicators', () => {
     expect(isArrayType('mytype][')).toBe(false)
     expect(isArrayType('mytype[] ')).toBe(false)
   })
+
+  it('identifies elementary types of array types', () => {
+    expect(getElementaryType('scoopity[]')).toEqual('scoopity')
+    expect(() => getElementaryType('woopity')).toThrow()
+  })
 })
 
-describe.skip('validate', () => {
-  it('', () => {
-
+describe('validate', () => {
+  it('validates primitive types', () => {
+    for (const p of POWERS) {
+      expect(() => validate[`bytes${p}`]()).not.toThrow()
+      expect(() => validate[`int${8*p}`]()).not.toThrow()
+      expect(() => validate[`uint${8*p}`]()).not.toThrow()
+    }
+    
+    expect(() => validate['address']()).not.toThrow()
+    expect(() => validate['bool']()).not.toThrow()
+    expect(() => validate['string']()).not.toThrow()
+    expect(() => validate['bytes']([0])).not.toThrow()
   })
 })

--- a/src/__tests__/verify.test.js
+++ b/src/__tests__/verify.test.js
@@ -1,0 +1,59 @@
+import { ec as EC } from 'elliptic'
+import { verify, verifyRawSignatureFromAddress, toEthereumAddress } from '../verify'
+
+const secp256k1 = EC('secp256k1')
+
+function kp() {
+  const keypair = secp256k1.genKeyPair()
+  const address = toEthereumAddress(keypair.getPublic().encode('hex'))
+
+  return { keypair, address }
+}
+
+describe('toEthereumAddress', () => {
+  it('handles 0x prefix', () => {
+    const { keypair } = kp()
+    const pubKey = keypair.getPublic().encode('hex')
+    expect(toEthereumAddress(pubKey)).toEqual(toEthereumAddress(`0x${pubKey}`))
+  })
+})
+
+describe('verifyRawSignatureFromAddress', () => {
+  it('verifies an arbitrary signature from a signature object', () => {
+    const { keypair, address } = kp()
+    const hash = Buffer.from('deadbeef', 'hex')
+    const sig = keypair.sign(hash)
+    expect(verifyRawSignatureFromAddress(hash, sig, address)).toBe(true)
+  })
+
+  it('verifies a concatenated buffer signature', () => {
+    // uncomment to be *extra* sure
+    // for (let i = 0; i < 100; i++) {
+      const { keypair, address } = kp()
+      const hash = Buffer.from('deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef', 'hex')
+      const sig = keypair.sign(hash)
+      const [r, s] = [sig.r.toString('hex'), sig.s.toString('hex')]
+      const buf =  `${r.padStart(64, '0')}${s.padStart(64, '0')}${sig.recoveryParam}`
+      expect(verifyRawSignatureFromAddress(hash, buf, address)).toBe
+    // }
+  })
+})
+
+describe('verify', () => {
+  const MailExample = require('./data/Mail.json')
+
+  it('verifies a request', () => {
+    const { keypair, address } = kp()
+    const signHash = Buffer.from(MailExample.results.Mail.signHash.slice(2), 'hex')
+    const sig = keypair.sign(signHash)
+    expect(() => verify(MailExample.request, sig, address)).not.toThrow()
+  })
+
+  it('throws an error for an invalid signature', () => {
+    const { keypair } = kp()
+    const signHash = Buffer.from(MailExample.results.Mail.signHash.slice(2), 'hex')
+    const sig = keypair.sign(signHash)
+    const { address } = kp() // different keypair!
+    expect(() => verify(MailExample.request, sig, address)).toThrow()
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import EIP712Domain from './Domain'
-import Type from './Type'
+import { verify } from './verify'
 
-export { Type, EIP712Domain }
+export default EIP712Domain
+export { verify }

--- a/src/primitives.js
+++ b/src/primitives.js
@@ -23,9 +23,9 @@ export function isArrayType(type) {
  * @param   {String} type 
  * @returns {String} 
  */
-export function getBaseType(type) {
+export function getElementaryType(type) {
   if (isArrayType(type)) return type.slice(0,-2)
-  throw new Error("Can't get base of non-array type")
+  throw new Error("Can't get element of non-array type")
 }
 
 /**
@@ -55,29 +55,29 @@ export function isPrimitiveType(type) {
   return isAtomicType(type) || isDynamicType(type)
 }
 
-/**
- * Validation utility function to switch on javascript types and
- * handle each with a custom function
- * @param   {Object}    handlers  An object mapping javascript types to a validation function for that type
- * @returns {Function}  a validation function which will delegate to one of the provided validators
- *                      according to the type of the input
- */
-function handleByType(target, handlers) {
-  return input => {
-    const jstype = typeof input
-    if (jstype in handlers) return handlers[jstype](input)
-    throw new Error(`Cannot convert javascript type ${jstype} to solidity type ${target}`)
-  }
-}
+// /**
+//  * Validation utility function to switch on javascript types and
+//  * handle each with a custom function
+//  * @param   {Object}    handlers  An object mapping javascript types to a validation function for that type
+//  * @returns {Function}  a validation function which will delegate to one of the provided validators
+//  *                      according to the type of the input
+//  */
+// function handleByType(target, handlers) {
+//   return input => {
+//     const jstype = typeof input
+//     if (jstype in handlers) return handlers[jstype](input)
+//     throw new Error(`Cannot convert javascript type ${jstype} to solidity type ${target}`)
+//   }
+// }
 
-/**
- * Throw an error with a given message. This is convenient for throwing
- * an error inside an expression without having to create a full function.
- * @param {String} message message for the error to be thrown
- */
-function reject(message) {
-  throw new Error(message)
-}
+// /**
+//  * Throw an error with a given message. This is convenient for throwing
+//  * an error inside an expression without having to create a full function.
+//  * @param {String} message message for the error to be thrown
+//  */
+// function reject(message) {
+//   throw new Error(message)
+// }
 
 /**
  * Validation functions for unifying javascript representations of solidity types

--- a/src/verify.js
+++ b/src/verify.js
@@ -1,0 +1,70 @@
+import { ec as EC } from 'elliptic'
+import { keccak256 } from 'js-sha3'
+
+import EIP712Domain from './Domain'
+
+const secp256k1 = new EC('secp256k1')
+
+/**
+ * Verify that a particular object was signed by a given
+ */
+export function verify(request, signature, address) {
+  const { domain, message } = EIP712Domain.fromSignatureRequest(request)
+
+  if (!message.verifySignature(signature, address)) {
+    throw new Error('Invalid signature for address over this object')
+  }
+
+  return { domain, message }
+}
+
+/**
+ * Verify a signed hash made by the owner of a particular ethereum address
+ * returning true if the signature is valid, and false otherwise
+ * @param   {Buffer}  data qq
+ * @param   {Object}  signature 
+ * @param   {String}  address 
+ * @returns {Boolean} indicator of the signature's validity
+ */
+export function verifyRawSignatureFromAddress(data, signature, address) {
+  const { r, s, v } = normalizeSignature(signature)
+
+  // Recover public key from signature, and convert to ethereum address
+  const publicKey = secp256k1.recoverPubKey(data, {r, s}, v).encode('hex')
+
+  const recoveredAddress = toEthereumAddress(publicKey)
+  return recoveredAddress === address
+}
+
+/**
+ * Convert a hex encoded secp256k1 public key to the equivalent ethereum address
+ * @param   {String} hexPublicKey
+ * @returns {String} address of account with given public key 
+ */
+export function toEthereumAddress(hexPublicKey) {
+  hexPublicKey = hexPublicKey.startsWith('0x') ? hexPublicKey.slice(2) : hexPublicKey 
+  return `0x${keccak256(Buffer.from(hexPublicKey, 'hex')).slice(-20).toString('hex')}`
+}
+
+/**
+ * Convert a string, or buffer signature to an object containing
+ * the three signature parameters r, s, v
+ * @param   {String|Object} sig
+ * @returns {Object}  A normalized signature object, containing strings r,s,v
+ */
+function normalizeSignature(sig) {
+  // Parse string into buffer
+  if (typeof sig === 'string') {
+    sig = {
+      r: Buffer.from(sig.slice(0, 64), 'hex'),
+      s: Buffer.from(sig.slice(64, 128), 'hex'),
+      v: parseInt(sig[128])
+    }
+  }
+
+  return {
+    r: sig.r,
+    s: sig.s,
+    v: 'recoveryParam' in sig ? sig.recoveryParam : sig.v,
+  }
+}


### PR DESCRIPTION
This PR adds support for signature verification, adding a new top level function `verify()`, which takes a signature request and signature/address combo, and returns a new domain and message object if the signature is valid.  Also add `verifySignature` method to StructureType classes, which checks an object's signHash against the provided signature and address, and a suite of tests for the verify module.

In addition test coverage is up to 99%, and some function/class names have been clarified.

Still to do ( in future pr )
- [ ] Replace incomplete alg for domain construction from signature request with topological sort
- [ ] Add real validation functions for primitive types
- [ ] Add abi serialization method for message signatures