### PR TITLE
feat: add topological sort to Domain.fromSignatureRequest

### DIFF
--- a/src/__tests__/Domain.test.js
+++ b/src/__tests__/Domain.test.js
@@ -176,4 +176,20 @@ describe('fromSignatureRequest', () => {
     expect(message.toObject()).toEqual(request.message)
     expect(message.toSignatureRequest()).toEqual(request)
   })
+
+  it('throws an error when given a domain with cyclic dependencies', () => {
+    const request = {
+      types: {
+        EIP712Domain: EIP712DomainProperties,
+        A: [{name: 'b', type: 'B'}],
+        B: [{name: 'c', type: 'C'}],
+        C: [{name: 'a', type: 'A'}]
+      },
+      domain: domainDef,
+      primaryType: 'A',
+      message: {A: {B: {C: 'A'}}} 
+    }
+
+    expect(() => EIP712Domain.fromSignatureRequest(request)).toThrow()
+  })
 })

--- a/src/__tests__/primitives.test.js
+++ b/src/__tests__/primitives.test.js
@@ -1,4 +1,4 @@
-import { validate, isPrimitiveType, isAtomicType, isDynamicType, isArrayType, getElementaryType } from '../primitives'
+import { validate, isPrimitiveType, isAtomicType, isDynamicType, isArrayType, isNotStructureType, getElementaryType } from '../primitives'
 
 const POWERS = [1, 2, 4, 8, 16, 32]
 
@@ -60,6 +60,15 @@ describe('type indicators', () => {
   it('identifies elementary types of array types', () => {
     expect(getElementaryType('scoopity[]')).toEqual('scoopity')
     expect(() => getElementaryType('woopity')).toThrow()
+  })
+
+  it('identifies arbitrarily nested arrays of primitive types as non-structure types', () => {
+    expect(isNotStructureType('bool')).toBe(true)
+    expect(isNotStructureType('bool[]')).toBe(true)
+    expect(isNotStructureType('string[][][][][][][][][][][][][][][]')).toBe(true)
+
+    expect(isNotStructureType('MyType')).toBe(false)
+    expect(isNotStructureType('YourType[]')).toBe(false)
   })
 })
 

--- a/src/primitives.js
+++ b/src/primitives.js
@@ -55,6 +55,18 @@ export function isPrimitiveType(type) {
   return isAtomicType(type) || isDynamicType(type)
 }
 
+/**
+ * Determine if the argument is not a structure type, i.e. it is a primitive type or an
+ * arbitrarily nested array of structure types
+ * @param {String} type
+ * @returns {Boolean}
+ */
+export function isNotStructureType(type) {
+  if (isPrimitiveType(type)) return true
+  if (isArrayType(type)) return isNotStructureType(getElementaryType(type))
+  return false
+}
+
 // /**
 //  * Validation utility function to switch on javascript types and
 //  * handle each with a custom function


### PR DESCRIPTION
Ensure that when creating a domain from a signature request, that the structure type dependency graph is acyclic, and that the types are instantiated in the proper order.
Additionally add new function isNotStructureType to primitives.js, to detect whether a particular type name is a primitive type or array of primitive types.

closes #3 